### PR TITLE
feature/keyof lookup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ key = "age";
 
 const mmConversionTable = {
   mm: 1,
+  cm: 10,
   m: 1e3,
   km: 1e6,
 };
@@ -23,4 +24,4 @@ function convertUnits(value: number, unit: keyof typeof mmConversionTable) {
   };
 }
 
-console.log(convertUnits(5600, "m"));
+console.log(convertUnits(5600, "cm"));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,26 @@
 type Human = {
-  type: "human";
   name: string;
-  age: bigint;
+  age: number;
 };
 
-function setAge(human: Human, age: Human["age"]) {
+type HumanKeys = keyof Human;
+
+let key: HumanKeys = "name";
+key = "age";
+
+const mmConversionTable = {
+  mm: 1,
+  m: 1e3,
+  km: 1e6,
+};
+
+function convertUnits(value: number, unit: keyof typeof mmConversionTable) {
+  const mmValue = value * mmConversionTable[unit];
   return {
-    ...human,
-    age,
+    mm: mmValue,
+    m: mmValue / 1e3,
+    km: mmValue / 1e6,
   };
 }
 
-const uhyo: Human = {
-  type: "human",
-  name: "uhyo",
-  age: 26n,
-};
-
-const uhyo2 = setAge(uhyo, 27n);
-console.log(uhyo2);
+console.log(convertUnits(5600, "m"));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,16 @@
+function get<T, K extends keyof T>(obj: T, key: K): T[K] {
+  return obj[key];
+}
+
 type Human = {
   name: string;
   age: number;
 };
 
-type HumanKeys = keyof Human;
-
-let key: HumanKeys = "name";
-key = "age";
-
-const mmConversionTable = {
-  mm: 1,
-  cm: 10,
-  m: 1e3,
-  km: 1e6,
+const uhyo: Human = {
+  name: "uhyo",
+  age: 26,
 };
 
-function convertUnits(value: number, unit: keyof typeof mmConversionTable) {
-  const mmValue = value * mmConversionTable[unit];
-  return {
-    mm: mmValue,
-    m: mmValue / 1e3,
-    km: mmValue / 1e6,
-  };
-}
-
-console.log(convertUnits(5600, "cm"));
+const uhyoName = get(uhyo, "name");
+const uhyoAge = get(uhyo, "age");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,35 +1,21 @@
-type Animal = {
-  tag: "animal";
-  species: string;
-}
-
 type Human = {
-  tag: "human";
+  type: "human";
   name: string;
+  age: number;
+};
+
+function setAge(human: Human, age: Human["age"]) {
+  return {
+    ...human,
+    age,
+  };
 }
 
-type Robot = {
-  tag: "robot";
-  name: string;
-}
+const uhyo: Human = {
+  type: "human",
+  name: "uhyo",
+  age: 26,
+};
 
-type User = Animal | Human | Robot;
-
-function getUserName1(user: User): string {
-  if (user.tag === "human") {
-    return user.name;
-  } else {
-    return "no name";
-  }
-}
-
-function getUserName2(user: User): string {
-  switch (user.tag) {
-    case "human":
-      return user.name;
-    case "animal":
-      return "no name";
-    case "robot":
-      return `CPU ${user.name}`;
-  }
-}
+const uhyo2 = setAge(uhyo, 26);
+console.log(uhyo2);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 type Human = {
   type: "human";
   name: string;
-  age: number;
+  age: bigint;
 };
 
 function setAge(human: Human, age: Human["age"]) {
@@ -14,8 +14,8 @@ function setAge(human: Human, age: Human["age"]) {
 const uhyo: Human = {
   type: "human",
   name: "uhyo",
-  age: 26,
+  age: 26n,
 };
 
-const uhyo2 = setAge(uhyo, 26);
+const uhyo2 = setAge(uhyo, 27n);
 console.log(uhyo2);


### PR DESCRIPTION
- lookup型を使えば型変更に柔軟に対応できる
- lookup型を引数として渡しておけば変更箇所が少なく済む
- keyofとtypeofを組み合わせることで引数の記述を受け取るオブジェクトプロパティのユニオン型に縛ることができる
